### PR TITLE
"If we've already built this test double" should not invoke the autoloader

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -40,6 +40,7 @@
  * starting with an "_" is for internal consumption only
  */
 class Phockito {
+	const MOCK_PREFIX = '__phockito_';
 
 	/* ** Static Configuration *
 		Feel free to change these at any time.
@@ -191,7 +192,7 @@ class Phockito {
 		}
 
 		// Build the short name of the mocker class based on the mocked classes shortname
-		$mockerShortName = '__phockito_'.$mockedShortName.($partial ? '_Spy' : '_Mock');
+		$mockerShortName = self::MOCK_PREFIX.$mockedShortName.($partial ? '_Spy' : '_Mock');
 		// And build the full class name of the mocker by prepending the namespace if appropriate
 		$mockerClass = (self::_has_namespaces() ? $mockedNamespace.'\\' : '') . $mockerShortName;
 

--- a/Phockito.php
+++ b/Phockito.php
@@ -196,7 +196,7 @@ class Phockito {
 		$mockerClass = (self::_has_namespaces() ? $mockedNamespace.'\\' : '') . $mockerShortName;
 
 		// If we've already built this test double, just return it
-		if (class_exists($mockerClass)) return $mockerClass;
+		if (class_exists($mockerClass, false)) return $mockerClass;
 
 		// If the mocked class is in a namespace, the test double goes in the same namespace
 		$namespaceDeclaration = $mockedNamespace ? "namespace $mockedNamespace;" : '';

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -3,6 +3,12 @@
 // Include Phockito
 require_once(dirname(dirname(__FILE__)) . '/Phockito.php');
 
+spl_autoload_register(function ($class) {
+	if (0 === strncmp($class, Phockito::MOCK_PREFIX, strlen(Phockito::MOCK_PREFIX))) {
+		throw new RuntimeException('Autoload attempted on a phockito mock class');
+	}
+}, true);
+
 /** Base class to mock */
 
 class PhockitoTest_MockMe {


### PR DESCRIPTION
This is a simple fix, stopping the autoloader from running during the 'have we already mocked this class' check. The second commit includes a regression test.
