### PR TITLE
Mocking return byRef methods

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -331,8 +331,8 @@ EOT;
 
     \$response = {$phockito}::__called($mockedClassString, \$instance, '{$method->name}', \$args);
   
-    if (\$response) return {$phockito}::__perform_response(\$response, \$args);
-    else return $failover;
+	\$result = \$response ? {$phockito}::__perform_response(\$response, \$args) : ($failover);
+    return \$result;
   }
 EOT;
 			}

--- a/Phockito.php
+++ b/Phockito.php
@@ -244,6 +244,9 @@ EOT;
 			// Get the modifiers for the function as a string (static, public, etc) - ignore abstract though, all mock methods are concrete
 			$modifiers = implode(' ', Reflection::getModifierNames($method->getModifiers() & ~(ReflectionMethod::IS_ABSTRACT)));
 
+			// See if the method is return byRef
+			$byRef = $method->returnsReference() ? "&" : "";
+
 			// PHP fragment that is the arguments definition for this method
 			$defparams = array(); $callparams = array();
 
@@ -303,7 +306,7 @@ EOT;
 			// Build an overriding method that calls Phockito::__called, and never calls the parent
 			else {
 				$php[] = <<<EOT
-  $modifiers function {$method->name}( $defparams ){
+  $modifiers function $byRef {$method->name}( $defparams ){
     \$args = func_get_args();
 
     \$backtrace = debug_backtrace();

--- a/Phockito.php
+++ b/Phockito.php
@@ -314,8 +314,8 @@ EOT;
 
     \$response = {$phockito}::__called($mockedClassString, \$instance, '{$method->name}', \$args);
   
-    if (\$response) return {$phockito}::__perform_response(\$response, \$args);
-    else return $failover;
+	\$result = \$response ? {$phockito}::__perform_response(\$response, \$args) : ($failover);
+    return \$result;
   }
 EOT;
 			}

--- a/Phockito.php
+++ b/Phockito.php
@@ -256,6 +256,9 @@ EOT;
 			// Get the modifiers for the function as a string (static, public, etc) - ignore abstract though, all mock methods are concrete
 			$modifiers = implode(' ', Reflection::getModifierNames($method->getModifiers() & ~(ReflectionMethod::IS_ABSTRACT)));
 
+			// See if the method is return byRef
+			$byRef = $method->returnsReference() ? "&" : "";
+
 			// PHP fragment that is the arguments definition for this method
 			$defparams = array(); $callparams = array();
 
@@ -320,7 +323,7 @@ EOT;
 			// Build an overriding method that calls Phockito::__called, and never calls the parent
 			else {
 				$php[] = <<<EOT
-  $modifiers function {$method->name}( $defparams ){
+  $modifiers function $byRef {$method->name}( $defparams ){
     \$args = func_get_args();
 
     \$backtrace = debug_backtrace();

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -32,10 +32,6 @@ interface PhockitoTest_MockInterface {
 /** Classes with different types of modifiers */
 final class PhockitoTest_Final {}
 
-interface PhockitoTest_MockInterfaceFooReturnsByReference{
-	function &Foo();
-}
-
 
 /** Classes with different types of methods */
 
@@ -46,7 +42,10 @@ class PhockitoTest_FooIsFinal { final function Foo() { } }
 class PhockitoTest_FooHasIntegerDefaultArgument { function Foo($a = 1) { } }
 class PhockitoTest_FooHasArrayDefaultArgument { function Foo($a = array(1,2,3)) { } }
 class PhockitoTest_FooHasByReferenceArgument { function Foo(&$a) { } }
+
+/** Classes that return byRef */
 class PhockitoTest_FooReturnsByReference_NoImplements { function &Foo() { return 5;} }
+interface PhockitoTest_MockInterfaceFooReturnsByReference{ function &Foo(); }
 class PhockitoTest_FooReturnsByReference_Implements implements PhockitoTest_MockInterfaceFooReturnsByReference { function &Foo() { return 5;} }
 
 /** A class to get Phockito to throw when verification fails, to tell difference between Phockito failure and other PHPUnit assert failures */
@@ -174,7 +173,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($mock->Bar('b'), 2);
 	}
 
-	function testMocksHaveIndependantReturnValueLists() {
+	function testMocksHaveIndependentReturnValueLists() {
 		$mock1 = Phockito::mock('PhockitoTest_MockMe');
 		Phockito::when($mock1->Foo())->return(1);
 
@@ -292,6 +291,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 	function testProvidingTooManyArgumentsToStubbingActionThrowsAnError() {
 		$mock = Phockito::mock('PhockitoTest_MockMe');
 		Phockito::when($mock->Foo())->return(1, 2);
+	}
 
 	function testCanSpecifyReturnValueForReferenceNoInterfaceImplemented() {
 		//this call will succeed even if the derived type's method doesn't also return by ref

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting( E_ALL|E_STRICT );
 
 // Include Phockito
 require_once(dirname(dirname(__FILE__)) . '/Phockito.php');
@@ -252,6 +253,7 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Quux', $mock->Quux());
 	}
 
+
 	/**
 	 * The raised error will be wrapped in an exception by PHPUnit
 	 * @expectedException PHPUnit_Framework_Error
@@ -290,6 +292,46 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 	function testProvidingTooManyArgumentsToStubbingActionThrowsAnError() {
 		$mock = Phockito::mock('PhockitoTest_MockMe');
 		Phockito::when($mock->Foo())->return(1, 2);
+
+	function testCanSpecifyReturnValueForReferenceNoInterfaceImplemented() {
+		//this call will succeed even if the derived type's method doesn't also return by ref
+		//If the return by ref doesn't come from an interface derived types can override it
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_NoImplements');
+		Phockito::when($mock->Foo())->return(4);
+		$res = &$mock->Foo();
+		$this->assertEquals(4, $res);
+
+	}
+
+	function testCanSpecifyReturnObjectForReferenceNoInterfaceImplemented() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+		$obj = new PhockitoTest_MockMe();
+		Phockito::when($mock->Foo())->return($obj);
+		$res = $mock->Foo();
+		$this->assertEquals($obj, $res);
+	}
+
+	function testCanSpecifyReturnValueForReferenceInterfaceImplemented() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+		Phockito::when($mock->Foo())->return(4);
+		$res = &$mock->Foo();
+		$this->assertEquals(4, $res);
+	}
+
+	function testCanSpecifyReturnObjectForReferenceInterfaceImplemented() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+		$obj = new stdClass();
+
+		Phockito::when($mock->Foo())->return($obj);
+		$res = &$mock->Foo();
+		$this->assertEquals($obj, $res);
+
 	}
 
 	/** Test validating **/

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -1,4 +1,5 @@
 <?php
+error_reporting( E_ALL|E_STRICT );
 
 // Include Phockito
 require_once(dirname(dirname(__FILE__)) . '/Phockito.php');
@@ -245,6 +246,46 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		Phockito::when($mock->Quux())->return('Quux');
 
 		$this->assertEquals('Quux', $mock->Quux());
+	}
+
+	function testCanSpecifyReturnValueForReferenceNoInterfaceImplemented() {
+		//this call will succeed even if the derived type's method doesn't also return by ref
+		//If the return by ref doesn't come from an interface derived types can override it
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_NoImplements');
+		Phockito::when($mock->Foo())->return(4);
+		$res = &$mock->Foo();
+		$this->assertEquals(4, $res);
+
+	}
+
+	function testCanSpecifyReturnObjectForReferenceNoInterfaceImplemented() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+		$obj = new PhockitoTest_MockMe();
+		Phockito::when($mock->Foo())->return($obj);
+		$res = $mock->Foo();
+		$this->assertEquals($obj, $res);
+	}
+
+	function testCanSpecifyReturnValueForReferenceInterfaceImplemented() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+		Phockito::when($mock->Foo())->return(4);
+		$res = &$mock->Foo();
+		$this->assertEquals(4, $res);
+	}
+
+	function testCanSpecifyReturnObjectForReferenceInterfaceImplemented() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+		$obj = new stdClass();
+
+		Phockito::when($mock->Foo())->return($obj);
+		$res = &$mock->Foo();
+		$this->assertEquals($obj, $res);
 	}
 
 	/** Test validating **/

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -27,6 +27,10 @@ interface PhockitoTest_MockInterface {
 	function Bar($a);
 }
 
+interface PhockitoTest_MockInterfaceFooReturnsByReference{
+	function &Foo();
+}
+
 /** Classes with different types of methods */
 
 class PhockitoTest_FooIsStatic { static function Foo() { } }
@@ -36,6 +40,8 @@ class PhockitoTest_FooIsFinal { final function Foo() { } }
 class PhockitoTest_FooHasIntegerDefaultArgument { function Foo($a = 1) { } }
 class PhockitoTest_FooHasArrayDefaultArgument { function Foo($a = array(1,2,3)) { } }
 class PhockitoTest_FooHasByReferenceArgument { function Foo(&$a) { } }
+class PhockitoTest_FooReturnsByReference_NoImplements { function &Foo() { return 5;} }
+class PhockitoTest_FooReturnsByReference_Implements implements PhockitoTest_MockInterfaceFooReturnsByReference { function &Foo() { return 5;} }
 
 /** A class to get Phockito to throw when verification fails, to tell difference between Phockito failure and other PHPUnit assert failures */
 
@@ -99,6 +105,33 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		$mock = Phockito::mock('PhockitoTest_FooHasByReferenceArgument');
 		$a = 1;
 		$this->assertNull($mock->Foo($a));
+	}
+
+	function testCanCreateMockMethodWithReturnByReference() {
+		//this call will succeed even if the derived type's method doesn't also return by ref
+		//If the return by ref doesn't come from an interface derived types can override it
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_NoImplements');
+		$res = &$mock->Foo();
+		$this->assertNull($res);
+
+		//we need to ensure derived type returns by ref
+		$clazz = new ReflectionClass($mock);
+		$fooMethod = $clazz->getMethod("Foo");
+		$this->assertTrue($fooMethod->returnsReference());
+	}
+
+	function testCanCreateMockMethodWithReturnByReferenceImplementingInterfaceWithReturnByRef() {
+		//this call will fatal error if the derived type's method doesn't also return by ref
+		//This is because it's defined like this in the interface (weird..)
+		$mock = Phockito::mock('PhockitoTest_FooReturnsByReference_Implements');
+
+		$res = &$mock->Foo();
+		$this->assertNull($res);
+
+		//we need to ensure derived type returns by ref
+		$clazz = new ReflectionClass($mock);
+		$fooMethod = $clazz->getMethod("Foo");
+		$this->assertTrue($fooMethod->returnsReference());
 	}
 
 	/** Test stubbing **/


### PR DESCRIPTION
Ran into an issue when mocking a return byRef method...to me PHP might have a bug here.

If a class has a return byRef method (ie public function &Foo()) then derived classes can override Foo without byRef (ie public function Foo()).

Phockito wasn't ensuring the derived was byRef, i wrote a test around this to ensure it is.  Maybe this should be optional..by ref is darn weird.

but...
If a class has a return byRef method (ie public function &Foo()) that comes from an interface then derived classes MUST override with the return ByRef.  Different behaviour in PHP..might be a bug

Anyways i added tests for this too.

The implementation was very simple
