### PR TITLE
Explicit stubbing methods to aid IDE code completion

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -566,6 +566,51 @@ class Phockito_WhenBuilder {
 
 		return $this;
 	}
+
+	/**
+	 * Commonly used methods, provided for benefit of code completion in IDEs.
+	 *
+	 * Note that "return" and "throw" cannot be added here, as they are PHP keywords.
+	 */
+
+	/**
+	 * Return $value when the stubbed method is called
+	 *
+	 * @param $value
+	 * @return $this
+	 */
+	function thenReturn($value) { return $this->__call('thenReturn', func_get_args()); }
+
+	/**
+	 * Throw $exception when the stubbed method is called
+	 *
+	 * @param $exception
+	 * @return $this
+	 */
+	function thenThrow($exception) { return $this->__call('thenThrow', func_get_args()); }
+
+	/**
+	 * Invoke $callback when the stubbed method is called
+	 *
+	 * @param $callback
+	 * @return $this
+	 */
+	function callback($callback) { return $this->__call('callback', func_get_args()); }
+	/**
+	 * Invoke $callback when the stubbed method is called
+	 *
+	 * @param $callback
+	 * @return $this
+	 */
+	function thenCallback($callback) { return $this->__call('thenCallback', func_get_args()); }
+
+	/**
+	 * Repeat the previous action (return, throw or callback) with the argument $arg when the stubbed method is called
+	 *
+	 * @param $arg
+	 * @return $this
+	 */
+	function then($arg) { return $this->__call('then', func_get_args()); }
 }
 
 /**

--- a/Phockito.php
+++ b/Phockito.php
@@ -579,7 +579,7 @@ class Phockito_WhenBuilder {
 	 * @param $value
 	 * @return $this
 	 */
-	function thenReturn($value) { return $this->__call('thenReturn', func_get_args()); }
+	function thenReturn($value) { return $this->__call(__FUNCTION__, func_get_args()); }
 
 	/**
 	 * Throw $exception when the stubbed method is called
@@ -587,7 +587,7 @@ class Phockito_WhenBuilder {
 	 * @param $exception
 	 * @return $this
 	 */
-	function thenThrow($exception) { return $this->__call('thenThrow', func_get_args()); }
+	function thenThrow($exception) { return $this->__call(__FUNCTION__, func_get_args()); }
 
 	/**
 	 * Invoke $callback when the stubbed method is called
@@ -595,14 +595,14 @@ class Phockito_WhenBuilder {
 	 * @param $callback
 	 * @return $this
 	 */
-	function callback($callback) { return $this->__call('callback', func_get_args()); }
+	function callback($callback) { return $this->__call(__FUNCTION__, func_get_args()); }
 	/**
 	 * Invoke $callback when the stubbed method is called
 	 *
 	 * @param $callback
 	 * @return $this
 	 */
-	function thenCallback($callback) { return $this->__call('thenCallback', func_get_args()); }
+	function thenCallback($callback) { return $this->__call(__FUNCTION__, func_get_args()); }
 
 	/**
 	 * Repeat the previous action (return, throw or callback) with the argument $arg when the stubbed method is called
@@ -610,7 +610,7 @@ class Phockito_WhenBuilder {
 	 * @param $arg
 	 * @return $this
 	 */
-	function then($arg) { return $this->__call('then', func_get_args()); }
+	function then($arg) { return $this->__call(__FUNCTION__, func_get_args()); }
 }
 
 /**

--- a/Phockito.php
+++ b/Phockito.php
@@ -506,6 +506,11 @@ interface Phockito_MockMarker {
 /**
  * A builder than is returned by Phockito::when to capture the methods that specify the stubbed responses
  * for a particular mocked method / arguments set
+ *
+ * @method Phockito_WhenBuilder return($value) thenReturn($value)
+ * @method Phockito_WhenBuilder throw($exception) thenThrow($exception)
+ * @method Phockito_WhenBuilder callback($callback) thenCallback($callback)
+ * @method Phockito_WhenBuilder then($arg)
  */
 class Phockito_WhenBuilder {
 
@@ -566,51 +571,6 @@ class Phockito_WhenBuilder {
 
 		return $this;
 	}
-
-	/**
-	 * Commonly used methods, provided for benefit of code completion in IDEs.
-	 *
-	 * Note that "return" and "throw" cannot be added here, as they are PHP keywords.
-	 */
-
-	/**
-	 * Return $value when the stubbed method is called
-	 *
-	 * @param $value
-	 * @return $this
-	 */
-	function thenReturn($value) { return $this->__call(__FUNCTION__, func_get_args()); }
-
-	/**
-	 * Throw $exception when the stubbed method is called
-	 *
-	 * @param $exception
-	 * @return $this
-	 */
-	function thenThrow($exception) { return $this->__call(__FUNCTION__, func_get_args()); }
-
-	/**
-	 * Invoke $callback when the stubbed method is called
-	 *
-	 * @param $callback
-	 * @return $this
-	 */
-	function callback($callback) { return $this->__call(__FUNCTION__, func_get_args()); }
-	/**
-	 * Invoke $callback when the stubbed method is called
-	 *
-	 * @param $callback
-	 * @return $this
-	 */
-	function thenCallback($callback) { return $this->__call(__FUNCTION__, func_get_args()); }
-
-	/**
-	 * Repeat the previous action (return, throw or callback) with the argument $arg when the stubbed method is called
-	 *
-	 * @param $arg
-	 * @return $this
-	 */
-	function then($arg) { return $this->__call(__FUNCTION__, func_get_args()); }
 }
 
 /**

--- a/Phockito_Globals.php
+++ b/Phockito_Globals.php
@@ -12,6 +12,9 @@ function spy() {
 	return call_user_func_array(array('Phockito', 'spy'), $args);
 }
 
+/**
+ * @return Phockito_WhenBuilder
+ */
 function when() {
 	$args = func_get_args();
 	return call_user_func_array(array('Phockito', 'when'), $args);


### PR DESCRIPTION
I don't know how you feel about this, but adds some explicit methods to Phockito_WhenBuilder (which all just call through to __call()); this means we get some code completion in IDEs (in particular, PHPStorm, which is what I'm using), but perhaps makes the Phockito code a bit messier.

There's also a phpdoc type hint on the global when() function, but hopefully that's not very controversial.

What do you think?
