### PR TITLE
Add PHPDoc type hint to fix PHPStorm inspection error

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -151,7 +151,11 @@ class Phockito {
 
 	public static function __perform_response($response, $args) {
 		if ($response['action'] == 'return') return $response['value'];
-		else if ($response['action'] == 'throw') { $class = $response['value']; throw (is_object($class) ? $class : new $class()); }
+		else if ($response['action'] == 'throw') {
+			/** @var Exception $class */
+			$class = $response['value'];
+			throw (is_object($class) ? $class : new $class());
+		}
 		else if ($response['action'] == 'callback') return call_user_func_array($response['value'], $args);
 		else user_error("Got unknown action {$response['action']} - how did that happen?", E_USER_ERROR);
 	}


### PR DESCRIPTION
This is basically a no-op change, just to fix a code inspection error in PHPStorm: it previously complained that "the thrown object must be an instance of the class Exception".

I first noticed this when including Phockito as a composer dependency on a project I'm working on; it's not a huge problem, but it's slightly annoying to have errors on that project (even if only in the /vendor directory).
