### PR TITLE
More informative error messages when stubbing

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -552,13 +552,26 @@ class Phockito_WhenBuilder {
 			$this->__phockito_setMethod($called, $args);
 		}
 		else {
+			if (count($args) !== 1) user_error("$called requires exactly one argument", E_USER_ERROR);
 			$value = $args[0]; $action = null;
 
 			if (preg_match('/return/i', $called)) $action = 'return';
 			else if (preg_match('/throw/i', $called)) $action = 'throw';
 			else if (preg_match('/callback/i', $called)) $action = 'callback';
-			else if ($called == 'then' && $this->lastAction) $action = $this->lastAction;
-			else user_error("Unknown when action $called - should contain return or throw somewhere in method name", E_USER_ERROR);
+			else if ($called == 'then') {
+				if ($this->lastAction) {
+					$action = $this->lastAction;
+				} else {
+					user_error(
+						"Cannot use then without previously invoking a \"return\", \"throw\", or \"callback\" action",
+						E_USER_ERROR
+					);
+				}
+			}
+			else user_error(
+				"Unknown when action $called - should contain \"return\", \"throw\" or \"callback\" somewhere in method name",
+				E_USER_ERROR
+			);
 
 			Phockito::$_responses[$this->instance][$this->method][$this->i]['steps'][] = array(
 				'action' => $action,

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -207,11 +207,51 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		$mock->Foo();
 	}
 
-	function testCanSpecificReturnValueForUndefinedFunction() {
+	function testCanSpecifyReturnValueForUndefinedFunction() {
 		$mock = Phockito::mock('PhockitoTest_MockMe');
 		Phockito::when($mock->Quux())->return('Quux');
 
 		$this->assertEquals('Quux', $mock->Quux());
+	}
+
+	/**
+	 * The raised error will be wrapped in an exception by PHPUnit
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 */
+	function testCannotUseThenWithoutAPreviousAction() {
+		$mock = Phockito::mock('PhockitoTest_MockMe');
+		Phockito::when($mock->Foo())->then(1);
+	}
+
+	/**
+	 * The raised error will be wrapped in an exception by PHPUnit
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 */
+	function testUnknownStubbingActionThrowsAnError() {
+		$mock = Phockito::mock('PhockitoTest_MockMe');
+		Phockito::when($mock->Foo())->thenDoSomethingUndefined(1);
+	}
+
+	/**
+	 * The raised error will be wrapped in an exception by PHPUnit
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 */
+	function testProvidingTooFewArgumentsToStubbingActionThrowsAnError() {
+		$mock = Phockito::mock('PhockitoTest_MockMe');
+		Phockito::when($mock->Foo())->return();
+	}
+
+	/**
+	 * The raised error will be wrapped in an exception by PHPUnit
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 */
+	function testProvidingTooManyArgumentsToStubbingActionThrowsAnError() {
+		$mock = Phockito::mock('PhockitoTest_MockMe');
+		Phockito::when($mock->Foo())->return(1, 2);
 	}
 
 	/** Test validating **/


### PR DESCRIPTION
I've moved multi-line function call close parens to their own line, as requested in [pull #16](https://github.com/hafriedlander/phockito/pull/16) and squashed into a single commit.
