### PR TITLE
Type coercion of matchers via mocks

### DIFF
--- a/HamcrestTypeBridge.php
+++ b/HamcrestTypeBridge.php
@@ -1,0 +1,16 @@
+<?php
+
+class HamcrestTypeBridge {
+	/**
+	 * Creates a special mock of $type which wraps the given $matcher.
+	 *
+	 * @param string $type Name of the class to subtype
+	 * @param Hamcrest_Matcher $matcher The matcher to proxy
+	 * @return Object A special mock of type $type that wraps $matcher, circumventing type issues.
+	 */
+	public static function argOfTypeThat($type, Hamcrest_Matcher $matcher) {
+		$mockOfType = Phockito::mock($type);
+		$mockOfType->__phockito_matcher = $matcher;
+		return $mockOfType;
+	}
+}

--- a/HamcrestTypeBridge_Globals.php
+++ b/HamcrestTypeBridge_Globals.php
@@ -1,0 +1,6 @@
+<?php
+require_once('HamcrestTypeBridge.php');
+
+function argOfTypeThat($type, \Hamcrest_Matcher $matcher) {
+	HamcrestTypeBridge::argOfTypeThat($type, $matcher);
+}

--- a/Phockito.php
+++ b/Phockito.php
@@ -111,8 +111,15 @@ class Phockito {
 			$u = $a[$i]; $v = $b[$i];
 
 			// If the argument in $a is a hamcrest matcher, call match on it. WONTFIX: Can't check if function was passed a hamcrest matcher
-			if (interface_exists('Hamcrest_Matcher') && $u instanceof Hamcrest_Matcher) {
-				if (!$u->matches($v)) return false;
+			if (interface_exists('Hamcrest_Matcher') && ($u instanceof Hamcrest_Matcher || isset($u->__phockito_matcher))) {
+				// The matcher can either be passed directly, or wrapped in a mock (for type safety reasons)
+				$matcher = null;
+				if ($u instanceof Hamcrest_Matcher) {
+					$matcher = $u;
+				} elseif (isset($u->__phockito_matcher)) {
+					$matcher = $u->__phockito_matcher;
+				}
+				if ($matcher != null && !$matcher->matches($v)) return false;
 			}
 			// Otherwise check for equality by checking the equality of the serialized version
 			else {
@@ -168,13 +175,12 @@ class Phockito {
 	 *
 	 * @static
 	 * @param bool $partial - Should test double be a partial or a full mock
-	 * @param string $mockerClass - The name of the class to create the mock as
 	 * @param string $mockedClass - The name of the class (or interface) to create a mock of
-	 * @return void
+	 * @return string The name of the mocker class
 	 */
 	protected static function build_test_double($partial, $mockedClass) {
 		// Bail if we were passed a classname that doesn't exist
-		if (!class_exists($mockedClass) && !interface_exists($mockedClass)) user_error("Can't mock non-existant class $mockedClass", E_USER_ERROR);
+		if (!class_exists($mockedClass) && !interface_exists($mockedClass)) user_error("Can't mock non-existent class $mockedClass", E_USER_ERROR);
 
 		// How to get a reference to the Phockito class itself
 		$phockito = self::_has_namespaces() ? '\\Phockito' : 'Phockito';
@@ -502,8 +508,13 @@ EOT;
 	static function include_hamcrest($include_globals = true) {
 		set_include_path(get_include_path().PATH_SEPARATOR.dirname(__FILE__).'/hamcrest-php/hamcrest');
 		
-		if ($include_globals) require_once('Hamcrest.php');
-		else require_once('Hamcrest/Matchers.php');
+		if ($include_globals) {
+			require_once('Hamcrest.php');
+			require_once('HamcrestTypeBridge_Globals.php');
+		} else {
+			require_once('Hamcrest/Matchers.php');
+			require_once('HamcrestTypeBridge.php');
+		}
 	}
 }
 

--- a/Phockito.php
+++ b/Phockito.php
@@ -182,6 +182,8 @@ class Phockito {
 		// Reflect on the mocked class
 		$reflect = new ReflectionClass($mockedClass);
 
+		if ($reflect->isFinal()) user_error("Can't mock final class $mockedClass", E_USER_ERROR);
+
 		// Build up an array of php fragments that make the mocking class definition
 		$php = array();
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ matches some rule.
 Hamcrest matchers are not included by default, so the first step is to call `Phockito::include_hamcrest();` immediately after including Phockito. 
 Note that this will import the Hamcrest matchers as global functions - passing false as an argument will keep your namespace clean by making all matchers only available as static methods of `Hamcrest` (at the expense of worse looking test code).
 
-Once included you can pass a hamcrest matcher as an argument in your when or verify rule, eg:
+Once included you can pass a Hamcrest matcher as an argument in your when or verify rule, eg:
 
 ```php
 class A {
@@ -99,7 +99,7 @@ $stub = Phockito::mock('A');
 Phockito::when($stub)->Foo(anything())->return('Zap');
 ```
 
-Some common hamcrest matchers:
+Some common Hamcrest matchers:
 
 - Core
 	* `anything` - always matches, useful if you don't care what the object under test is
@@ -125,6 +125,29 @@ Some common hamcrest matchers:
 
 In Mockito, the methods when building a stub are limited to thenReturns, thenThrows. In Phockito, you can use any method
 as long as it has 'return' or 'throw' in it, so `Phockito::when(...)->return(1)->thenReturn(2)` is fine.
+
+#### Type-safe argument matching
+
+In Mockito, to use a Hamcrest matcher, the `argThat` method is used to satisfy the type checker. In PHP, a little extra
+help is needed. Phockito provides the `argOfTypeThat` for provided Hamcrest matchers to type-hinted parameters:
+
+```php
+class A {
+    function Foo(B $b){ }
+}
+
+class B {}
+
+$stub = Phockito::mock('A');
+$b = new B();
+Phockito::when($stub)->Foo(argOfTypeThat('B', is(equalTo($b))))->return('Zap');
+```
+
+It's also possible to pass a mock to 'when', rather than the result of a method call on a mock, e.g.
+`Phockito::when($mock)->methodToStub(...)->thenReturn(...)`. This side-steps the type system entirely.
+
+Note that `argOfTypeThat` is only compatible with object type-hints; arguments with `array` or `callable` type-hints
+cannot be handled in a type-safe way.
 
 #### Verify 'times' argument changed
 
@@ -157,7 +180,7 @@ Phockito::when($mock->Bar(1))->return('A');
 
 $mock->Bar(1); // Returns 'A'
 $mock->Bar(1, 2); // Also returns 'A'
-$mock->Bar(1, 3); // Returns null, since no stubed return value matches
+$mock->Bar(1, 3); // Returns null, since no stubbed return value matches
 ```
 
 #### Return typing
@@ -167,7 +190,7 @@ PHP, so we always return null. TODO: Support using phpdoc @return when declared.
 
 ## TODO
 
- - Mochito-specific hamcrest matchers (anyString, etc)
+ - Mockito-specific hamcrest matchers (anyString, etc)
  - Ordered verification
 
 ## License

--- a/tests/PhockitoHamcrestTest.php
+++ b/tests/PhockitoHamcrestTest.php
@@ -7,7 +7,10 @@ Phockito::include_hamcrest();
 class PhockitoHamcrestTest_MockMe {
 	function Foo($a, $b) { throw new Exception('Base method Foo was called'); }
 	function Bar($a) { throw new Exception('Base method Bar was called'); }
+	function Baz(PhockitoHamcrestTest_PassMe $a) { throw new Exception('Base method Baz was called'); }
 }
+
+class PhockitoHamcrestTest_PassMe {}
 
 class PhockitoHamcrestTest extends PHPUnit_Framework_TestCase {
 
@@ -32,5 +35,13 @@ class PhockitoHamcrestTest extends PHPUnit_Framework_TestCase {
 		$mock->Bar('Bam!');
 		
 		Phockito::verify($mock, 2)->Bar(stringValue());
+	}
+
+	function testCanStubTypeHintedMethodsByPassingOnlyMockIntoWhen() {
+		$mock = Phockito::mock('PhockitoHamcrestTest_MockMe');
+
+		Phockito::when($mock)->Baz(anything())->return('PassMe');
+
+		$this->assertEquals($mock->Baz(new PhockitoHamcrestTest_PassMe()), 'PassMe');
 	}
 }

--- a/tests/PhockitoHamcrestTypeBridgeTest.php
+++ b/tests/PhockitoHamcrestTypeBridgeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+// Include Phockito
+require_once(dirname(dirname(__FILE__)) . '/Phockito.php');
+Phockito::include_hamcrest();
+
+class PhockitoHamcrestTypeBridgeTest_MockMe {
+    function Foo(PhockitoHamcrestTypeBridgeTest_PassMe $a) { throw new Exception('Base method Foo was called'); }
+    function Bar(array $a) { throw new Exception('Base method Bar was called'); }
+}
+
+class PhockitoHamcrestTypeBridgeTest_MockMe_Constructor {
+	function __construct(PhockitoHamcrestTypeBridgeTest_PassMe $passMe) { throw new Exception('Base constructor was called'); }
+	function Foo(PhockitoHamcrestTypeBridgeTest_PassMe $a) { throw new Exception('Base method Foo was called'); }
+}
+
+final class PhockitoHamcrestTypeBridgeTest_MockMe_Final {
+}
+
+class PhockitoHamcrestTypeBridgeTest_PassMe {}
+
+class PhockitoHamcrestTypeBridgeTest_PassMe_MatcherMethods {
+	public function matches($item) { throw new Exception('Base method matches was called'); }
+}
+
+class PhockitoHamcrestTypeBridgeTest extends PHPUnit_Framework_TestCase {
+    function testCanStubUsingMatchersForTypeHintedObjectArguments() {
+        $mock = Phockito::mock('PhockitoHamcrestTypeBridgeTest_MockMe');
+
+        Phockito::when($mock->Foo(
+			HamcrestTypeBridge::argOfTypeThat('PhockitoHamcrestTypeBridgeTest_PassMe',
+				anInstanceOf('PhockitoHamcrestTypeBridgeTest_PassMe'))))
+			->return('PassMe');
+
+        $this->assertEquals($mock->Foo(new PhockitoHamcrestTypeBridgeTest_PassMe()), 'PassMe');
+    }
+
+	function testCanBridgeTypeWithTypeHintedConstructor() {
+		$mock = Phockito::mock('PhockitoHamcrestTypeBridgeTest_MockMe_Constructor');
+
+		Phockito::when($mock->Foo(
+			HamcrestTypeBridge::argOfTypeThat('PhockitoHamcrestTypeBridgeTest_PassMe',
+				anInstanceOf('PhockitoHamcrestTypeBridgeTest_PassMe'))))
+			->return('PassMe');
+
+		$this->assertEquals($mock->Foo(new PhockitoHamcrestTypeBridgeTest_PassMe()), 'PassMe');
+	}
+
+	/**
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 * @expectedExceptionMessage Can't mock non-existent class NotAClass
+	 */
+	function testBridgingInvalidTypeThrowsException() {
+		$mock = Phockito::mock('PhockitoHamcrestTypeBridgeTest_MockMe');
+
+		Phockito::when($mock->Foo(
+			HamcrestTypeBridge::argOfTypeThat('NotAClass',
+				anInstanceOf('NotAClass'))))
+			->return('PassMe');
+	}
+
+	/**
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 */
+	function testCannotBridgeFinalType() {
+		HamcrestTypeBridge::argOfTypeThat('PhockitoHamcrestTypeBridgeTest_MockMe_Final', anArray());
+	}
+}

--- a/tests/PhockitoNamespaceTest_Actual.php
+++ b/tests/PhockitoNamespaceTest_Actual.php
@@ -3,6 +3,7 @@
 namespace {
 	// Include Phockito
 	require_once(dirname(dirname(__FILE__)) . '/Phockito.php');
+	require_once(dirname(dirname(__FILE__)) . '/HamcrestTypeBridge.php');
 	Phockito::include_hamcrest();
 
 	// Turn on strict error checking - this makes sure that argument types are checked properly, etc
@@ -92,6 +93,16 @@ namespace {
 
 			Phockito::when($mock->Foo($arg))->return('Bar');
 			$this->assertEquals($mock->Foo($arg), 'Bar');
+		}
+
+		function testCanBridgeNamespacedClass() {
+			$mockMatcher = new \Hamcrest_Core_IsInstanceOf('\org\phockito\tests\PhockitoNamespaceTest_MockMe');
+
+			$typeBridge = \HamcrestTypeBridge::argOfTypeThat(
+				'\org\phockito\tests\PhockitoNamespaceTest_MockMe',
+				$mockMatcher);
+
+			$this->assertThat($typeBridge, $this->isInstanceOf('\org\phockito\tests\PhockitoNamespaceTest_MockMe'));
 		}
 
 	}

--- a/tests/PhockitoTest.php
+++ b/tests/PhockitoTest.php
@@ -27,6 +27,9 @@ interface PhockitoTest_MockInterface {
 	function Bar($a);
 }
 
+/** Classes with different types of modifiers */
+final class PhockitoTest_Final {}
+
 /** Classes with different types of methods */
 
 class PhockitoTest_FooIsStatic { static function Foo() { } }
@@ -345,6 +348,14 @@ class PhockitoTest extends PHPUnit_Framework_TestCase {
 		$mock = Phockito::mock('PhockitoTest_MockMe');
 		$mock->Foo();
 		Phockito::verify($mock, '2+')->Foo();
+	}
+
+	/**
+	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedExceptionCode E_USER_ERROR
+	 */
+	function testCannotMockFinalClass() {
+		Phockito::mock('PhockitoTest_Final');
 	}
 
 }


### PR DESCRIPTION
A method for supplying Hamcrest matchers to type-hinted parameters when stubbing, as discussed in #15.

I've used your suggestion of wrapping the matcher in a mock, rather than the larger code change I originally had on my proof of concept branch.
