### PR TITLE
Move Phockito_WhenBuilder method hints to own line

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -532,9 +532,12 @@ interface Phockito_MockMarker {
  * A builder than is returned by Phockito::when to capture the methods that specify the stubbed responses
  * for a particular mocked method / arguments set
  *
- * @method Phockito_WhenBuilder return($value) thenReturn($value)
- * @method Phockito_WhenBuilder throw($exception) thenThrow($exception)
- * @method Phockito_WhenBuilder callback($callback) thenCallback($callback)
+ * @method Phockito_WhenBuilder return($value)
+ * @method Phockito_WhenBuilder thenReturn($value)
+ * @method Phockito_WhenBuilder throw($exception)
+ * @method Phockito_WhenBuilder thenThrow($exception)
+ * @method Phockito_WhenBuilder callback($callback)
+ * @method Phockito_WhenBuilder thenCallback($callback)
  * @method Phockito_WhenBuilder then($arg)
  */
 class Phockito_WhenBuilder {


### PR DESCRIPTION
As it turns out, IntelliJ ignores the second `@method` defined here, so I've moved each declaration to its own `@method` line. It's a bit more verbose, but at least it works as expected.

(I originally added these `@method` lines, but I'm not sure why I wrote them like this - looks like it's just an oversight. Sorry!)
