### PR TITLE
Fix argOfTypeThat documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ class B {}
 
 $stub = Phockito::mock('A');
 $b = new B();
-Phockito::when($stub)->Foo(argOfTypeThat('B', is(equalTo($b))))->return('Zap');
+Phockito::when($stub->Foo(argOfTypeThat('B', is(equalTo($b)))))->return('Zap');
 ```
 
 It's also possible to pass a mock to 'when', rather than the result of a method call on a mock, e.g.


### PR DESCRIPTION
Another little mistake of mine, I think - the point of argOfTypeThat() is to satisfy type checking, but if you use when($stub)->Foo() then no type checking takes place (as noted in the docs already). I've updated the argOfTypeThat() example to use when($stub->Foo()) instead, which makes a bit more sense.
