### PR TITLE
Added a third parameter to Phockito::Verify

### DIFF
--- a/Phockito.php
+++ b/Phockito.php
@@ -471,24 +471,26 @@ EOT;
 		}
 	}
 
-	/**
-	 * Verify builder. Takes a mock instance and an optional number of times to verify against. Returns a
-	 * DSL object that catches the method to verify
-	 *
-	 * @static
-	 * @param Phockito_Mock $mock - The mock instance to verify
-	 * @param string $times - The number of times the method should be called, either a number, or a number followed by "+"
-	 * @return Phockito_VerifyBuilder
-	 */
-	static function verify($mock, $times = 1) {
-		return new Phockito_VerifyBuilder($mock->__phockito_class, $mock->__phockito_instanceid, $times);
+    /**
+     * Verify builder. Takes a mock instance and an optional number of times to verify against. Returns a
+     * DSL object that catches the method to verify
+     *
+     * @static
+     * @param Phockito_Mock $mock - The mock instance to verify
+     * @param int|string $times - The number of times the method should be called, either a number, or a number followed by "+"
+     * @param Boolean $ignore_arguments - The ignore arguments parameter is used to set the function to verify with or without method arguments
+     * @return Phockito_VerifyBuilder
+     */
+	static function verify($mock, $times = 1, $ignore_arguments = false) {
+		return new Phockito_VerifyBuilder($mock->__phockito_class, $mock->__phockito_instanceid, $times, $ignore_arguments);
 	}
 
-	/**
-	 * Reset a mock instance. Forget all calls and stubbed responses for a given instance
-	 * @static
-	 * @param Phockito_Mock $mock - The mock instance to reset
-	 */
+    /**
+     * Reset a mock instance. Forget all calls and stubbed responses for a given instance
+     * @static
+     * @param Phockito_Mock $mock - The mock instance to reset
+     * @param null $method
+     */
 	static function reset($mock, $method = null) {
 		// Get the instance ID. Only resets instance-specific info ATM
 		$instance = $mock->__phockito_instanceid;
@@ -623,24 +625,26 @@ class Phockito_VerifyBuilder {
 	protected $class;
 	protected $instance;
 	protected $times;
+    protected $ignore_arguments;
 
-	function __construct($class, $instance, $times) {
+    function __construct($class, $instance, $times, $ignore_arguments) {
 		$this->class = $class;
 		$this->instance = $instance;
 		$this->times = $times;
+        $this->ignore_arguments = $ignore_arguments;
 
 		if (self::$exception_class === null) {
 			if (class_exists('PHPUnit_Framework_AssertionFailedError')) self::$exception_class = "PHPUnit_Framework_AssertionFailedError";
 			else self::$exception_class = "Exception";
 		}
-
-	}
+    }
 
 	function __call($called, $args) {
 		$count = 0;
 
 		foreach (Phockito::$_call_list as $call) {
-			if ($call['instance'] == $this->instance && $call['method'] == $called && Phockito::_arguments_match($this->class, $called, $args, $call['args'])) {
+			if ($call['instance'] == $this->instance && $call['method'] == $called &&
+                    ($this->ignore_arguments || Phockito::_arguments_match($this->class, $called, $args, $call['args']))) {
 				$count++;
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ $iterator->asort();
 Phockito::verify($iterator)->append('Test');
 // 1 is default - can also do 2, 3  for exact numbers, or 1+ for at least one, or 0 for never
 Phockito::verify($iterator, 1)->asort();
-// Verify without caring what parameters were used
-Phockito::verify($iterator, 1)->append();
+// Verify without caring what parameters were used, just pass a third parameter (ignore_arguments) with value true
+Phockito::verify($iterator, 1, true)->append();
 ```
 
 If PHPUnit is available, on failure verify throws a `PHPUnit_Framework_AssertionFailedError` (looks like an assertion failure),

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $iterator->asort();
 Phockito::verify($iterator)->append('Test');
 // 1 is default - can also do 2, 3  for exact numbers, or 1+ for at least one, or 0 for never
 Phockito::verify($iterator, 1)->asort();
+// Verify without caring what parameters were used
+Phockito::verify($iterator, 1)->append();
 ```
 
 If PHPUnit is available, on failure verify throws a `PHPUnit_Framework_AssertionFailedError` (looks like an assertion failure),

--- a/tests/PhockitoHamcrestTest.php
+++ b/tests/PhockitoHamcrestTest.php
@@ -44,4 +44,15 @@ class PhockitoHamcrestTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($mock->Baz(new PhockitoHamcrestTest_PassMe()), 'PassMe');
 	}
+
+    function testVerifyIgnoreArguments() {
+        $mock = Phockito::mock('PhockitoHamcrestTest_MockMe');
+
+        $mock->Bar('String');
+        $mock->Bar(1);
+        $mock->Bar(new PhockitoHamcrestTest_MockMe());
+        $mock->Bar(null);
+
+        Phockito::verify($mock, 4, true)->Bar();
+    }
 }


### PR DESCRIPTION
Now you can also ignore arguments if you just want to verify the call no matter what argument was used.
